### PR TITLE
Fixed legislators API request

### DIFF
--- a/server/dbOperations/legislators.js
+++ b/server/dbOperations/legislators.js
@@ -2,7 +2,6 @@ var pg = require("./postgresInteractions");
 
 exports.addLegislators = function (legislators, cb) {
 	var query = "INSERT INTO Legislators (name, sunlightid, img, website, party, state, chamber) VALUES ($1, $2, $3, $4, $5, $6, $7) "
-
 	legislators.forEach(function (legislator) {
 		var values = [legislator.full_name,
 			legislator.leg_id, legislator.photo_url,

--- a/server/dbOperations/postgresInteractions.js
+++ b/server/dbOperations/postgresInteractions.js
@@ -5,7 +5,7 @@ exports.query = function (newQuery, values, cb) {
 	var client = new pg.Client(connectionString);
 	client.connect(function (err) {
 		if (values) {
-			client.query(newQuery, values, function (err) {
+			client.query(newQuery, values, function (err, body) {
 				if (cb) {
 					cb(err, body);
 				}

--- a/server/public/seedData/bills.js
+++ b/server/public/seedData/bills.js
@@ -47,6 +47,7 @@ var getStateBills = function (state, lastUpdateDate, page) {
 };
 
 var getAllStatesBills = function (lastUpdateDate) {
+  console.log("Seeding Bills...")
   statesList.forEach(function (state) {
     getStateBills(state.abbreviation, lastUpdateDate)
   })

--- a/server/public/seedData/legislators.js
+++ b/server/public/seedData/legislators.js
@@ -5,12 +5,12 @@ var legislators = require('../../dbOperations/legislators')
 
 var baseURL = "http://openstates.org/api/v1/legislators/?"
 module.exports = function (cb) {
-
+	console.log("Seeding legislators...")
 	var seedStateLegs = function (state, stateIndex) {
-		var apiReq = baseURL + "state=" + state + "&apikey="+ "61a5c87624ce4cc49d08e6e7918510f0";
+		var apiReq = baseURL + "state=" + state.abbreviation + "&apikey="+ "61a5c87624ce4cc49d08e6e7918510f0";
 		request(apiReq, function (err, resp, body)  {
-			legislators.addLegislators(JSON.parse(body), function () {
-				if (index === statesList.length) {
+			legislators.addLegislators(JSON.parse(body), function (err, body) {
+				if (stateIndex === statesList.length) {
 					cb();
 				}
 			});


### PR DESCRIPTION
- Corrected Legislators API request URL: Passed state object rather than state abbreviation to Legislators API request. 
- Added logs to know what part of the seeding process you are in. 
- Fixed Postgres query bug: Didn't pass the body to the callback
